### PR TITLE
feat: changing light switch command to async on buttonclick.

### DIFF
--- a/loadingBox2dGui/loadingBox2dGui.presenters/MainPresenter.cs
+++ b/loadingBox2dGui/loadingBox2dGui.presenters/MainPresenter.cs
@@ -105,9 +105,9 @@ namespace loadingBox2dGui.presenters
             }
         }
 
-        private void View_LightStateChangedRequested(object sender, ChangeLightStateEventArgs e)
+        private async void View_LightStateChangedRequested(object sender, ChangeLightStateEventArgs e)
         {
-            _lightComm.WriteLightState(e.State);
+            await Task.Run(() => _lightComm.WriteLightState(e.State));
         }
 
         private void View_ProgramCloseRequested(object sender, FormClosingEventArgs e)

--- a/loadingBox2dGui/loadingBox2dGui.presenters/MainPresenter.cs
+++ b/loadingBox2dGui/loadingBox2dGui.presenters/MainPresenter.cs
@@ -89,18 +89,18 @@ namespace loadingBox2dGui.presenters
         {
             Logger.Debug("Call [Camera Start]");
 
-           await _camComm.StartCamera();
+            await _camComm.StartCamera();
             _view.LhImage = _camComm.GetImage(_config.CameraConfigs.Keys.ToList()[0]);
             _view.RhImage = _camComm.GetImage(_config.CameraConfigs.Keys.ToList()[1]);
             Logger.Debug("Complete [Camera Start]");
         }
 
-        private void View_ConnectCameraRequested(object sender, EventArgs e)
+        private async void View_ConnectCameraRequested(object sender, EventArgs e)
         {
             if (!_camComm.IsConnected)
             {
                 Logger.Debug("Call [Camera Connect]");
-                _camComm.Connect();
+                await Task.Run(() => _camComm.Connect());
                 Logger.Debug("Complete [Camera Connect]");
             }
         }


### PR DESCRIPTION
**[배경]**
적재함 2D 에서 오늘 Modbus Poll 을 켜둔 상황에서 Light 버튼 클릭을 한 뒤 프로그램이 (Freeze) 무응답 상태로 전환되었습니다. 
현장에서 확인 결과 Modbus Poll 을 켜두었을때는 조명이 변하지 않는 것으로 확인 되어, Light On/Off 호출 시 처리 되지 않아 UI Thread 를 잡고 있는 것으로 확인되었습니다. 

**[조치사항]** 
Light Button 을 포함한 다른 버튼 클릭 콜백의 함수들을 비동기로 변경하였습니다.  

**[BackLog]**
정확히 어떤 시점에서 Light 변경 요청이 멈춘것인지 확인이 필요합니다. (Suspects: TCP Connect, WriteRegister ...) 