### PR TITLE
feat: calling plc connect when disconnect event occurs

### DIFF
--- a/loadingBox2dGui/loadingBox2dGui.presenters/MainPresenter.cs
+++ b/loadingBox2dGui/loadingBox2dGui.presenters/MainPresenter.cs
@@ -146,9 +146,19 @@ namespace loadingBox2dGui.presenters
             Logger.Info("Plc Connected Received");
         }
 
-        private void PlcComm_PlcDisconnected(object sender, EventArgs e)
+        private async void PlcComm_PlcDisconnected(object sender, EventArgs e)
         {
             Logger.Info("Plc Disconnected Received");
+            if (_mode == OperationMode.Auto && _plcComm != null)
+            {
+                await _plcComm.ConnectAsync();
+                if (_plcComm.IsConnected)
+                {
+                    RegisterPlcEventHandler();
+                }
+                _view.IsPlcConnected = _plcComm.IsConnected;
+                _view.RefreshPlcStatus();
+            }
         }
 
         private void PlcComm_VisionUpdate(object sender, VisionUpdateEventArgs e)


### PR DESCRIPTION
**[배경]** 
현장에서 PLC 관련 작업으로 인해 PLC 연결이 해제되었으나, 재연결을 시도하지 않습니다. 

**[변경점]**
PLC 가 연결이 끊긴 경우 기존의 Melsec PLC 을 활용하는 프로그램들(프라이머, 실러, etc) 에서 Disconnect Event 시 Presenter 에서 재연결을 시도하는 기능을 반영하였습니다. 